### PR TITLE
Some missing BuildRequires I ran into on CentOS 7

### DIFF
--- a/cnijfilter2.spec
+++ b/cnijfilter2.spec
@@ -24,6 +24,12 @@ Vendor: CANON INC.
 Group: Applications/Publishing
 Source0: cnijfilter2-source-%{version}-%{release}.tar.gz
 BuildRequires: cups-devel
+# libxml/parser.h:
+BuildRequires: libxml2-devel
+# libusb.h:
+BuildRequires: libusbx-devel
+# usb.h:
+BuildRequires: libusb-devel
 Requires:  cups
 
 


### PR DESCRIPTION
They're fairly simple/obvious to some users, but if you are trying to make it as easy as possible, best to explicitly require.